### PR TITLE
Add multi-platform installer generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,11 @@ pip install -r requirements.txt
 python build_installer.py
 ```
 
-- On Windows this produces `dist/subwoofer_simulation.exe`.
-- On macOS running the script creates `dist/subwoofer_simulation` which can be
-  packaged with `pkgbuild` or similar to create a `.pkg` installer.
+The script now creates two executables and, on macOS, a `.pkg` installer:
+
+- `dist/subwoofer_simulation.exe` – GUI application
+- `dist/subwoofer_simulation_console.exe` – console-enabled version
+- `dist/subwoofer_simulation.pkg` on macOS if `pkgbuild` is available
 
 After building, you can use platform-specific tools such as Inno Setup (Windows)
-or `pkgbuild`/`productbuild` (macOS) to wrap the executable in a standard
-installer package.
+or `productbuild` (macOS) to further customise the installer packages.

--- a/build_installer.py
+++ b/build_installer.py
@@ -1,14 +1,21 @@
 #!/usr/bin/env python3
-"""Build standalone executables for the Subwoofer Simulator."""
+"""Build standalone executables and a macOS installer for the Subwoofer Simulator."""
 import argparse
 import subprocess
+import sys
+import shutil
 from pathlib import Path
 
 
-def run_pyinstaller(windowed: bool) -> None:
+def run_pyinstaller(name: str, windowed: bool, dest: Path) -> None:
+    """Invoke PyInstaller to create a single executable."""
     args = [
         "pyinstaller",
         "--onefile",
+        "--distpath",
+        str(dest),
+        "--name",
+        name,
     ]
     if windowed:
         args.append("--windowed")
@@ -16,13 +23,53 @@ def run_pyinstaller(windowed: bool) -> None:
     subprocess.check_call(args)
 
 
+def build_pkg(binary: Path, pkg_path: Path) -> None:
+    """Create a simple macOS ``.pkg`` installer using ``pkgbuild``."""
+    if shutil.which("pkgbuild") is None:
+        print("pkgbuild not found - skipping macOS package creation", file=sys.stderr)
+        return
+
+    root = binary.parent / "pkgroot" / "usr" / "local" / "bin"
+    root.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(binary, root / binary.name)
+
+    subprocess.check_call(
+        [
+            "pkgbuild",
+            "--root",
+            str(root.parent.parent),
+            "--identifier",
+            "com.example.subwoofer-sim",
+            "--version",
+            "0.1.0",
+            str(pkg_path),
+        ]
+    )
+    shutil.rmtree(binary.parent / "pkgroot")
+
+
 def main() -> None:
-    parser = argparse.ArgumentParser(description="Create standalone executable")
+    parser = argparse.ArgumentParser(
+        description="Create Windows executables and a macOS package if possible"
+    )
     parser.add_argument(
-        "--console", action="store_true", help="Show console window (default hides)"
+        "--dist",
+        type=Path,
+        default=Path("dist"),
+        help="Output directory for generated files",
     )
     args = parser.parse_args()
-    run_pyinstaller(not args.console)
+
+    dist = args.dist
+    dist.mkdir(exist_ok=True)
+
+    # Build console and GUI executables
+    run_pyinstaller("subwoofer_simulation_console", False, dist)
+    run_pyinstaller("subwoofer_simulation", True, dist)
+
+    # On macOS also create a .pkg using the GUI executable
+    if sys.platform == "darwin":
+        build_pkg(dist / "subwoofer_simulation", dist / "subwoofer_simulation.pkg")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- update build script to produce GUI and console executables
- automatically create a macOS `.pkg` if `pkgbuild` is available
- document new outputs in the README

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68555f9d4eb8832d8c570dd3472bdd06