### PR TITLE
Add core and backend test suites

### DIFF
--- a/frontend/subwoofer-sim-ui/tests/AppLayout.test.tsx
+++ b/frontend/subwoofer-sim-ui/tests/AppLayout.test.tsx
@@ -1,0 +1,28 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import AppLayout from '../src/components/layout/AppLayout';
+
+vi.mock('../src/store/simulation', () => ({
+  useSimulationStore: () => ({
+    currentProject: null,
+    isSimulating: false,
+    simulationProgress: { progress: 0, current_step: 'idle' },
+    startSimulation: vi.fn(),
+    stopSimulation: vi.fn(),
+  }),
+}));
+
+vi.mock('../src/store/connection', () => ({
+  useConnectionStore: () => ({ isConnected: true, connectionError: null, serverVersion: '1.0' }),
+}));
+
+describe('AppLayout', () => {
+  it('renders children', () => {
+    render(
+      <AppLayout>
+        <div data-testid="child" />
+      </AppLayout>
+    );
+    expect(screen.getByTestId('child')).toBeInTheDocument();
+  });
+});

--- a/frontend/subwoofer-sim-ui/tests/ConnectionIndicator.test.tsx
+++ b/frontend/subwoofer-sim-ui/tests/ConnectionIndicator.test.tsx
@@ -1,0 +1,16 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import ConnectionIndicator from '../src/components/common/ConnectionIndicator';
+
+
+describe('ConnectionIndicator', () => {
+  it('renders connected state', () => {
+    render(<ConnectionIndicator isConnected={true} />);
+    expect(screen.getByText(/Connected/i)).toBeInTheDocument();
+  });
+
+  it('renders disconnected state', () => {
+    render(<ConnectionIndicator isConnected={false} reconnectAttempts={0} />);
+    expect(screen.getByText(/Offline/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/subwoofer-sim-ui/tests/ControlPanel.test.tsx
+++ b/frontend/subwoofer-sim-ui/tests/ControlPanel.test.tsx
@@ -1,0 +1,20 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import ControlPanel from '../src/components/panels/ControlPanel';
+
+vi.mock('../src/components/panels/SimulationPanel', () => ({ SimulationPanel: () => <div>SimulationPanel</div> }));
+vi.mock('../src/components/panels/SourcesPanel', () => ({ SourcesPanel: () => <div>SourcesPanel</div> }));
+vi.mock('../src/components/panels/OptimizationPanel', () => ({ OptimizationPanel: () => <div>OptimizationPanel</div> }));
+vi.mock('../src/components/panels/ProjectsPanel', () => ({ ProjectsPanel: () => <div>ProjectsPanel</div> }));
+vi.mock('../src/components/panels/ResultsPanel', () => ({ ResultsPanel: () => <div>ResultsPanel</div> }));
+
+vi.mock('../src/store/simulation', () => ({ useSimulationStore: () => ({}) }));
+
+
+describe('ControlPanel', () => {
+  it('renders tab labels', () => {
+    render(<ControlPanel />);
+    expect(screen.getByRole('tab', { name: /Simulation/i })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: /Sources/i })).toBeInTheDocument();
+  });
+});

--- a/frontend/subwoofer-sim-ui/tests/OptimizationPanel.test.tsx
+++ b/frontend/subwoofer-sim-ui/tests/OptimizationPanel.test.tsx
@@ -1,0 +1,10 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { OptimizationPanel } from '../src/components/panels/OptimizationPanel';
+
+describe('OptimizationPanel', () => {
+  it('shows coming soon message', () => {
+    render(<OptimizationPanel />);
+    expect(screen.getByText(/Coming Soon/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/subwoofer-sim-ui/tests/ProjectsPanel.test.tsx
+++ b/frontend/subwoofer-sim-ui/tests/ProjectsPanel.test.tsx
@@ -1,0 +1,10 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { ProjectsPanel } from '../src/components/panels/ProjectsPanel';
+
+describe('ProjectsPanel', () => {
+  it('shows coming soon message', () => {
+    render(<ProjectsPanel />);
+    expect(screen.getByText(/Coming Soon/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/subwoofer-sim-ui/tests/ResultsPanel.test.tsx
+++ b/frontend/subwoofer-sim-ui/tests/ResultsPanel.test.tsx
@@ -1,0 +1,10 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { ResultsPanel } from '../src/components/panels/ResultsPanel';
+
+describe('ResultsPanel', () => {
+  it('shows coming soon message', () => {
+    render(<ResultsPanel />);
+    expect(screen.getByText(/Coming Soon/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/subwoofer-sim-ui/tests/SimulationPanel.test.tsx
+++ b/frontend/subwoofer-sim-ui/tests/SimulationPanel.test.tsx
@@ -1,0 +1,20 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import SimulationPanel from '../src/components/panels/SimulationPanel';
+
+vi.mock('../src/store/simulation', () => ({
+  useSimulationStore: () => ({
+    simulationParams: { frequency: 80, speed_of_sound: 343, grid_resolution: 0.1, room_vertices: [] },
+    updateSimulationParams: vi.fn(),
+    isSimulating: false,
+    startSimulation: vi.fn(),
+    stopSimulation: vi.fn(),
+  }),
+}));
+
+describe('SimulationPanel', () => {
+  it('renders frequency settings', () => {
+    render(<SimulationPanel />);
+    expect(screen.getByText(/Frequency Settings/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/subwoofer-sim-ui/tests/SimulationProgress.test.tsx
+++ b/frontend/subwoofer-sim-ui/tests/SimulationProgress.test.tsx
@@ -1,0 +1,23 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import SimulationProgress from '../src/components/common/SimulationProgress';
+
+const baseProgress = {
+  progress: 50,
+  current_step: 'calculating_spl',
+  estimated_time: 120,
+  chunks_received: 1,
+  total_chunks: 2,
+};
+
+describe('SimulationProgress', () => {
+  it('renders full variant by default', () => {
+    render(<SimulationProgress progress={baseProgress} />);
+    expect(screen.getByText(/calculating/i)).toBeInTheDocument();
+  });
+
+  it('renders compact variant', () => {
+    render(<SimulationProgress progress={baseProgress} variant="compact" />);
+    expect(screen.getByText(/50/)).toBeInTheDocument();
+  });
+});

--- a/frontend/subwoofer-sim-ui/tests/SourcesPanel.test.tsx
+++ b/frontend/subwoofer-sim-ui/tests/SourcesPanel.test.tsx
@@ -1,0 +1,21 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import SourcesPanel from '../src/components/panels/SourcesPanel';
+
+vi.mock('../src/store/simulation', () => ({
+  useCurrentSources: () => [],
+  useSelectedSources: () => [],
+  useSimulationStore: () => ({
+    addSource: vi.fn(),
+    updateSource: vi.fn(),
+    removeSource: vi.fn(),
+    selectSources: vi.fn(),
+  }),
+}));
+
+describe('SourcesPanel', () => {
+  it('renders no sources message', () => {
+    render(<SourcesPanel />);
+    expect(screen.getByText(/No sources added/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/subwoofer-sim-ui/tests/SplViewer.test.tsx
+++ b/frontend/subwoofer-sim-ui/tests/SplViewer.test.tsx
@@ -1,0 +1,13 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import SplViewer from '../src/components/visualization/SplViewer';
+
+vi.mock('react-plotly.js', () => ({ default: () => <div data-testid="plot" /> }));
+vi.mock('../src/store/simulation', () => ({ useSimulationStore: () => ({ currentProject: null }) }));
+
+describe('SplViewer', () => {
+  it('renders without data', () => {
+    render(<SplViewer sources={[]} viewState={{ zoom:1, pan:[0,0], center:[0,0], rotation:0 }} onViewStateChange={() => {}} />);
+    expect(screen.getByTestId('plot')).toBeInTheDocument();
+  });
+});

--- a/frontend/subwoofer-sim-ui/tests/audioTheme.test.ts
+++ b/frontend/subwoofer-sim-ui/tests/audioTheme.test.ts
@@ -1,0 +1,12 @@
+import { describe, it, expect } from 'vitest';
+import { getSplColor, getFrequencyColor } from '../src/theme/audioTheme';
+
+describe('audio theme utilities', () => {
+  it('getSplColor returns low color', () => {
+    expect(getSplColor(60)).toMatch('#2E7D32');
+  });
+
+  it('getFrequencyColor returns bass color', () => {
+    expect(getFrequencyColor(100)).toMatch('#3F51B5');
+  });
+});

--- a/frontend/subwoofer-sim-ui/tests/connectionStore.test.ts
+++ b/frontend/subwoofer-sim-ui/tests/connectionStore.test.ts
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import { useConnectionStore } from '../src/store/connection';
+
+describe('connection store', () => {
+  it('has initial disconnected state', () => {
+    const state = useConnectionStore.getState();
+    expect(state.is_connected).toBe(false);
+  });
+});

--- a/frontend/subwoofer-sim-ui/tests/simulationStore.test.ts
+++ b/frontend/subwoofer-sim-ui/tests/simulationStore.test.ts
@@ -1,0 +1,10 @@
+import { describe, it, expect } from 'vitest';
+import { useSimulationStore } from '../src/store/simulation';
+
+describe('simulation store', () => {
+  it('creates default project', () => {
+    useSimulationStore.getState().createDefaultProject();
+    const state = useSimulationStore.getState();
+    expect(state.currentProject).not.toBeNull();
+  });
+});

--- a/frontend/subwoofer-sim-ui/tests/types.test.ts
+++ b/frontend/subwoofer-sim-ui/tests/types.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from 'vitest';
+import { isSourceData, isServerEvent, isSplMapData } from '../src/types';
+
+describe('type guards', () => {
+  it('validates SourceData', () => {
+    expect(isSourceData({ id:'1', x:0, y:0, spl_rms:80, gain_db:0, delay_ms:0, angle:0, polarity:1 })).toBe(true);
+  });
+  it('invalid SourceData returns false', () => {
+    expect(isSourceData({})).toBe(false);
+  });
+  it('validates ServerEvent', () => {
+    expect(isServerEvent({ type:'connected', timestamp:0, data:{} })).toBe(true);
+  });
+  it('validates SplMapData', () => {
+    expect(isSplMapData({ X:[[0]], Y:[[0]], SPL:[[0]], frequency:80, timestamp:0 })).toBe(true);
+  });
+});

--- a/tests/test_acoustic_engine.py
+++ b/tests/test_acoustic_engine.py
@@ -1,0 +1,35 @@
+import unittest
+import numpy as np
+
+from core.acoustic_engine import AcousticEngine, calculate_spl_vectorized
+from core.config import SUB_DTYPE
+
+
+class TestAcousticEngine(unittest.TestCase):
+    """Tests for acoustic engine calculations."""
+
+    def test_calculate_spl_vectorized_basic(self):
+        px = np.array([0.0])
+        py = np.array([0.0])
+        freq = 60.0
+        c_val = 343.0
+        sources = np.array([(0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 1)], dtype=SUB_DTYPE)
+        result = calculate_spl_vectorized(px, py, freq, c_val, sources)
+        self.assertEqual(result.shape, px.shape)
+
+    def test_get_wavelength(self):
+        engine = AcousticEngine()
+        wl = engine.get_wavelength(100.0)
+        self.assertAlmostEqual(wl, 343.0 / 100.0)
+
+    def test_validate_sources(self):
+        engine = AcousticEngine()
+        valid_sources = np.array([(0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 1)], dtype=SUB_DTYPE)
+        self.assertTrue(engine.validate_sources(valid_sources))
+
+        invalid_dtype = np.array([(0.0, 0.0)], dtype=[('x', float), ('y', float)])
+        self.assertFalse(engine.validate_sources(invalid_dtype))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,25 @@
+import unittest
+from core.config import SimulationConfig
+
+
+class TestSimulationConfig(unittest.TestCase):
+    """Tests for SimulationConfig."""
+
+    def test_defaults_present(self):
+        cfg = SimulationConfig()
+        self.assertIn('sub_spl_rms', cfg.default_values)
+        self.assertIsInstance(cfg.acoustic_params['speed_of_sound'], float)
+
+    def test_param_range_update_and_get(self):
+        cfg = SimulationConfig()
+        cfg.update_param_range('gain_db', -10.0, 10.0)
+        self.assertEqual(cfg.get_param_range('gain_db'), (-10.0, 10.0))
+
+    def test_validate_param_value(self):
+        cfg = SimulationConfig()
+        self.assertTrue(cfg.validate_param_value('gain_db', 0.0))
+        self.assertFalse(cfg.validate_param_value('gain_db', -40.0))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -1,0 +1,14 @@
+import unittest
+from backend.api.models.events import create_connection_event, EventType
+
+
+class TestEvents(unittest.TestCase):
+    def test_create_connection_event(self):
+        event = create_connection_event('session1', '1.0.0')
+        self.assertEqual(event.type, EventType.CONNECTED)
+        self.assertEqual(event.session_id, 'session1')
+        self.assertIn('server_version', event.data)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_simulation_service.py
+++ b/tests/test_simulation_service.py
@@ -1,0 +1,16 @@
+import unittest
+import asyncio
+from backend.api.services.websocket_manager import WebSocketManager
+from backend.api.services.simulation_service import SimulationService
+
+
+class TestSimulationService(unittest.TestCase):
+    def test_calculate_point_spl(self):
+        manager = WebSocketManager()
+        service = SimulationService(manager)
+        result = asyncio.run(service.calculate_point_spl(0.0, 0.0, 60.0))
+        self.assertIsInstance(result, float)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_websocket_manager.py
+++ b/tests/test_websocket_manager.py
@@ -1,0 +1,47 @@
+import unittest
+import asyncio
+from backend.api.services.websocket_manager import WebSocketManager
+
+
+class DummyWebSocket:
+    def __init__(self):
+        self.accepted = False
+        self.closed = False
+        self.sent = []
+
+    async def accept(self):
+        self.accepted = True
+
+    async def send_text(self, text):
+        self.sent.append(text)
+
+    async def close(self, code=1000, reason=""):
+        self.closed = True
+
+    async def ping(self):
+        pass
+
+
+class TestWebSocketManager(unittest.TestCase):
+    def test_connect_and_disconnect(self):
+        manager = WebSocketManager()
+        ws = DummyWebSocket()
+        session_id = asyncio.run(manager.connect(ws))
+        self.assertTrue(ws.accepted)
+        self.assertIn(session_id, manager.active_connections)
+        asyncio.run(manager.disconnect(session_id))
+        self.assertNotIn(session_id, manager.active_connections)
+
+    def test_join_project_and_send(self):
+        manager = WebSocketManager()
+        ws = DummyWebSocket()
+        session_id = asyncio.run(manager.connect(ws))
+        asyncio.run(manager.join_project(session_id, "proj1"))
+        self.assertIn("proj1", manager.project_sessions)
+        asyncio.run(manager.send_to_session(session_id, {"hello": "world"}))
+        self.assertTrue(ws.sent)
+        asyncio.run(manager.disconnect(session_id))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add tests for acoustic engine calculations
- cover simulation config logic
- test backend event factories
- validate websocket manager connection flow
- include simulation service point SPL test

## Testing
- `python scripts/run_tests.py`

------
https://chatgpt.com/codex/tasks/task_e_6866f2721598832dba35f18c2b746e22